### PR TITLE
Add check for svg document

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -134,6 +134,10 @@ function ready() {
 }
 
 function getTextFromTextOnlyDocument() {
+  if (!document.body) {
+    return;
+  }
+  
   const bodyChildren = document.body.childNodes;
   const firstChild = bodyChildren[0];
 


### PR DESCRIPTION
If it was a SVG file (e.g. https://www.w3.org/TR/SVG/images/struct/grouping01.svg), `document.body` would be `null`. 