### PR TITLE
Add check and alert for larger JSON files

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -87,6 +87,12 @@ listen((port, msg) => {
       port.postMessage(['NOT JSON', 'technically JSON but not an object or array']);
       port.disconnect();
       return;
+    } 
+    // If it's an empty object or array, display without the formatting
+    else if (Object.entries(obj).length === 0 || obj.length === 0) {
+      port.postMessage(['NOT JSON', 'empty objects']);
+      port.disconnect();
+      return;
     }
 
     // And send it the message to confirm that we're now formatting (so it can show a spinner)

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -87,12 +87,6 @@ listen((port, msg) => {
       port.postMessage(['NOT JSON', 'technically JSON but not an object or array']);
       port.disconnect();
       return;
-    } 
-    // If it's an empty object or array, display without the formatting
-    else if (Object.entries(obj).length === 0 || obj.length === 0) {
-      port.postMessage(['NOT JSON', 'empty objects']);
-      port.disconnect();
-      return;
     }
 
     // And send it the message to confirm that we're now formatting (so it can show a spinner)

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -115,7 +115,13 @@ function insertFormatOptionBar() {
 function ready() {
   // First, check if it's plain text and exit if not
   const plainText = getTextFromTextOnlyDocument();
-  if (!plainText || plainText.length > 3000000) {
+  if (!plainText) {
+    port.disconnect();
+    return;
+  }
+  // Second, check if length is larger than 3MB
+  if (plainText.length > 3000000) {
+    alert('JSON Formatter Error: Cannot parse JSON larger than 3MB');
     port.disconnect();
     return;
   }

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -115,13 +115,9 @@ function insertFormatOptionBar() {
 function ready() {
   // First, check if it's plain text and exit if not
   const plainText = getTextFromTextOnlyDocument();
-  if (!plainText) {
-    port.disconnect();
-    return;
-  }
-  // Second, check if length is larger than 3MB
-  if (plainText.length > 3000000) {
-    alert('JSON Formatter Error: Cannot parse JSON larger than 3MB');
+  if (!plainText || plainText.length > 300000) {
+    // If there is plain text and it's over 3MB, send alert
+    plainText && alert('JSON Formatter Error: Cannot parse JSON larger than 3MB');
     port.disconnect();
     return;
   }

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -115,7 +115,7 @@ function insertFormatOptionBar() {
 function ready() {
   // First, check if it's plain text and exit if not
   const plainText = getTextFromTextOnlyDocument();
-  if (!plainText || plainText.length > 300000) {
+  if (!plainText || plainText.length > 3000000) {
     // If there is plain text and it's over 3MB, send alert
     plainText && alert('JSON Formatter Error: Cannot parse JSON larger than 3MB');
     port.disconnect();


### PR DESCRIPTION
This PR addresses Issue [#22](https://github.com/callumlocke/json-formatter/issues/22) from the original repo.

* My approach for this iteration was to add an alert for large JSON files. This would be good feedback for the user when trying to parse JSON.
```js
// First, check if it's plain text and exit if not
  const plainText = getTextFromTextOnlyDocument();
  if (!plainText || plainText.length > 3000000) {
    // If there is plain text and it's over 3MB, send alert
    plainText && alert('JSON Formatter Error: Cannot parse JSON larger than 3MB');
    port.disconnect();
    return;
  }
```
* Since issue [#67](https://github.com/callumlocke/json-formatter/issues/67) from the same included a possible solution for parsing large JSON files, this may be included in the next iteration