### PR TITLE
typo in Xcode

### DIFF
--- a/src/js/lib/themes.js
+++ b/src/js/lib/themes.js
@@ -57,7 +57,7 @@ export const themes = {
     type: 'Light'
   },
   xcode: {
-    name: 'XCode',
+    name: 'Xcode',
     type: 'Light'
   },
   ambiance: {


### PR DESCRIPTION
Source: https://developer.apple.com/xcode/
Official case has always been `Xcode`.